### PR TITLE
修正textarea不可写情况下\n不还行的问题

### DIFF
--- a/src/components/VueFormMaking/components/GenerateForm.vue
+++ b/src/components/VueFormMaking/components/GenerateForm.vue
@@ -215,6 +215,10 @@ export default {
                 }
               })]
             }
+          } else {
+            for (const key in this.models) {
+              this.models[key] = this.models[key].replace(/\n/g, "<br />")
+            }
           }
         }
       }

--- a/src/components/VueFormMaking/components/GenerateFormItem.vue
+++ b/src/components/VueFormMaking/components/GenerateFormItem.vue
@@ -73,8 +73,8 @@
         />
       </template>
       <template v-else>
-        <div>
-          {{ dataModel }}
+        <div v-html="dataModel">
+          <!-- {{ dataModel }} -->
         </div>
       </template>
     </template>


### PR DESCRIPTION
表单元素存在textarea的情况下，如果值存在多行情况，preview模式下，值无法换行，简单调整了VueFoemMaking中的GenerateForm.Vue和GenerateFormItem.Vue这两个组件