### PR TITLE
fix: mac, ios 端格式化字符串日期兼容性问题

### DIFF
--- a/src/utils/costum.js
+++ b/src/utils/costum.js
@@ -9,6 +9,10 @@ export function parseTime(time, pattern) {
   if (typeof time === 'object') {
     date = time
   } else {
+    // 兼容 Mac, ios
+    if ((typeof time === 'string') && (/-/g.test(time))) {
+      time = time.replace(/-/g, '/')
+    }
     if ((typeof time === 'string') && (/^[0-9]+$/.test(time))) {
       time = parseInt(time)
     }


### PR DESCRIPTION
ios里不支持 '-' 连接的日期，会返回 invalid Date，此处统一处理为 `/`